### PR TITLE
Add map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ let doTask = task => {
   finishToken();
 };
 
-Promise.map(someBigList, doTask, { concurrency: () => maximizer.concurrency });
+maximizer.map(someBigList, doTask);
 ```
 
 ### Instructions
@@ -40,5 +40,7 @@ The maximizer has 3 inputs:
 
 To start processing one task, simply call `startItem` and get back a function that you execute when the task is done executing.  
 
-Whatever is controlling concurrency of tasks should check for the latest `concurrency` property on the maximizer.  Right now `Promise.map` does not allow for concurrency to be modified as execution changes.
+Whatever is controlling concurrency of tasks should check for the latest `concurrency` property on the maximizer.  `etl` supports dynamic concurrency, but most promise libraries do not.
+
+You can use `map` on your `ConcurrencyMaximizer` to maximize promise solving over that array.
 

--- a/concurrency-maximizer.js
+++ b/concurrency-maximizer.js
@@ -106,22 +106,31 @@ class ConcurrencyMaximizer {
   time() { return new Date().getTime(); }
 
   map(array, fn) {
-    let nextIndex = 0, currentActive = 0, results = [], outerResolve = null;
-    let finalPromise = new Promise(resolve => outerResolve = resolve);
+    let nextIndex = 0, currentActive = 0, results = [], outerResolve = null, outerReject = null;
+    let finalPromise = new Promise((resolve,reject) => {
+      outerResolve = resolve;
+      outerReject = reject;
+    });
     let fill = () => {
       while (currentActive < this.concurrency && nextIndex < array.length) {
         currentActive++;
         let token = this.startItem();
-        results[nextIndex] = fn(array[nextIndex]);
-        results[nextIndex].finally(() => {
-          token();
-          currentActive--;
-          fill();
-        });
+        let fnResult = fn(array[nextIndex]);
+        results[nextIndex] = fnResult;
+        fnResult
+          .catch(e => {
+            nextIndex = array.length;
+            outerReject(e);
+          })
+          .finally(() => {
+            token();
+            currentActive--;
+            fill();
+          });
         nextIndex++;
-      }
-      if (nextIndex === array.length) {
-        outerResolve(Promise.all(results));
+        if (nextIndex === array.length) {
+          outerResolve(Promise.all(results));
+        }
       }
     };
     fill();

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   "private": false,
   "devDependencies": {
     "bluebird": "^3.1.5",
-    "tap": "10.3.2"
+    "tap": "14.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concurrency-maximizer",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Monitor and maximize concurrency to prevent overloading external resources",
   "main": "concurrency-maximizer.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -257,3 +257,22 @@ t.test('test map',function(t) {
   });
 });
 
+
+t.test('test map with rejection', function(t) {
+
+  let maximizer = new ConcurrencyMaximizer(10, 0.75);
+  let steps = 100;
+  let maximimumConcurrency = 0;
+
+  let arr = [...new Array(steps)].map((d,i) => i);
+  let promise = maximizer.map(arr, inp => {
+    maximimumConcurrency = Math.max(maximimumConcurrency, maximizer.concurrency);
+    if (inp === 50) {
+      return Promise.reject('woops');
+    }
+    return Promise.delay(Math.random() * 150 + 100).then(() => inp * 2);
+  });
+
+  return t.rejects(promise, 'should reject');
+});
+


### PR DESCRIPTION
Most promise libraries do not support dynamic concurrency during `map` operations, so I wrote a simple `map` fn.  This will apply your maximizer over the array, limiting the number of in flight promises at a time.